### PR TITLE
Support Django 2.2.x and 3.0.x via django-jsonfield-backport

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Graham Ullrich <graham@flyingcracker.com>
 Katherine Michel <kthrnmichel@gmail.com>
 Mfon Eti-mfon <mfonetimfon@gmail.com>
 Patrick Scott Best <patrickscottbest@gmail.com>
+Jacob Wegner <jacobwegner@gmail.com>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 * [Overview](#overview)
   * [Supported Django and Python Versions](#supported-django-and-python-versions)
 * [Documentation](#documentation)
-  * [Installation](#installation)
+  * [Installation in Django >=3.1](#installation-in-django-31)
+  * [Installation in Django <3.1](#installation-in-django-31-1)  
   * [Usage](#usage)
   * [Signals](#signals)
 * [Change Log](#change-log)
@@ -178,6 +179,7 @@ was just logged.
 ## Change Log
 
 ### 5.1
+
 * Restore Django 2.2 and 3.0 support via [`django-jsonfield-backport`](https://github.com/laymonage/django-jsonfield-backport)
 
 ### 5.0.0

--- a/README.md
+++ b/README.md
@@ -63,13 +63,15 @@ a job manager like `celery` or `pyres` so that the calls become asynchronous.
 
 Django / Python | 3.6 | 3.7 | 3.8
 --------------- | --- | --- | ---
-2.2  |  *  |  *  |  *
-3.0  |  *  |  *  |  *
+2.2*  |  *  |  *  |  *
+3.0*  |  *  |  *  |  *
+3.1  |  *  |  *  |  *
 
+_*see Installation in Django < 3.1 below*_
 
 ## Documentation
 
-### Installation
+### Installation in Django >=3.1
 
 To install pinax-eventlog:
 
@@ -82,6 +84,35 @@ Add `pinax.eventlog` to your `INSTALLED_APPS` setting:
 ```python
     INSTALLED_APPS = [
         # other apps
+        "pinax.eventlog",
+    ]
+```
+
+Run the app's migrations:
+
+```shell
+    $ python manage.py migrate eventlog
+```
+
+### Installation in Django <3.1
+
+Django 3.1 introduced a JSON model field on all supported backends:
+
+https://docs.djangoproject.com/en/3.1/releases/3.1/#jsonfield-for-all-supported-database-backends
+
+To use `pinax-eventlog` on sites running Django 2.2 and 3.0, you'll want to install the package with the
+`django-lts` extra:
+
+```shell
+    $ pip install pinax-eventlog[django-lts]
+```
+
+Add `pinax.eventlog` and `django_jsonfield_backport` to your `INSTALLED_APPS` setting:
+
+```python
+    INSTALLED_APPS = [
+        # other apps
+        "django_jsonfield_backport,
         "pinax.eventlog",
     ]
 ```
@@ -145,6 +176,14 @@ was just logged.
 
 
 ## Change Log
+
+### 5.1
+* Restore Django 2.2 and 3.0 support via [`django-jsonfield-backport`](https://github.com/laymonage/django-jsonfield-backport)
+
+### 5.0.0
+
+* Switch to Django 3.1's JSONField
+* Reset migrations _(see discussion in [#33](https://github.com/pinax/pinax-eventlog/issues/32#issuecomment-674414709))_
 
 ### 4.0.1
 

--- a/pinax/eventlog/compat.py
+++ b/pinax/eventlog/compat.py
@@ -1,0 +1,12 @@
+"""
+For Django < 3.1, rely on django-jsonfield-backport for JSONField
+functionality
+
+https://github.com/laymonage/django-jsonfield-backport#installation
+https://github.com/laymonage/django-jsonfield-backport#why-create-another-one
+"""
+
+try:
+    from django.db.models import JSONField  # noqa
+except ImportError:
+    from django_jsonfield_backport.models import JSONField  # noqa

--- a/pinax/eventlog/migrations/0001_initial.py
+++ b/pinax/eventlog/migrations/0001_initial.py
@@ -6,6 +6,8 @@ from django.db import migrations, models
 import django.db.models.deletion
 import django.utils.timezone
 
+from ..compat import JSONField
+
 
 class Migration(migrations.Migration):
 
@@ -24,7 +26,7 @@ class Migration(migrations.Migration):
                 ('timestamp', models.DateTimeField(db_index=True, default=django.utils.timezone.now)),
                 ('action', models.CharField(db_index=True, max_length=50)),
                 ('object_id', models.PositiveIntegerField(blank=True, null=True)),
-                ('extra', models.JSONField(blank=True, encoder=django.core.serializers.json.DjangoJSONEncoder)),
+                ('extra', JSONField(blank=True, encoder=django.core.serializers.json.DjangoJSONEncoder)),
                 ('content_type', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='contenttypes.contenttype')),
                 ('user', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
             ],

--- a/pinax/eventlog/models.py
+++ b/pinax/eventlog/models.py
@@ -5,6 +5,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.utils import timezone
 
+from .compat import JSONField
 from .signals import event_logged
 
 
@@ -20,7 +21,7 @@ class Log(models.Model):
     content_type = models.ForeignKey(ContentType, null=True, on_delete=models.SET_NULL, blank=True)
     object_id = models.PositiveIntegerField(null=True, blank=True)
     obj = GenericForeignKey("content_type", "object_id")
-    extra = models.JSONField(encoder=DjangoJSONEncoder, blank=True)
+    extra = JSONField(encoder=DjangoJSONEncoder, blank=True)
 
     @property
     def template_fragment_name(self):

--- a/pinax/eventlog/tests/tests.py
+++ b/pinax/eventlog/tests/tests.py
@@ -1,11 +1,13 @@
 from datetime import timedelta
 
+import django
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.utils import timezone
 
+from ..compat import JSONField
 from ..mixins import EventLogMixin
 from ..models import Log, log
 from ..signals import event_logged
@@ -107,3 +109,15 @@ class TestMixins(TestCase):
         mixin.request = RequestMock(user)
         mixin.log_action()
         self.assertEquals(Log.objects.all()[0].action, "CREATE_USER")
+
+
+class TestCompat(TestCase):  # noqa
+    def test_jsonfield(self):
+        if django.VERSION < (3, 1):
+            from django_jsonfield_backport.models import \
+                JSONField as BackportJSONField  # noqa
+            assert JSONField == BackportJSONField
+        if django.VERSION >= (3, 1):
+            from django.db.models import \
+                JSONField as SupportedJSONField  # noqa
+            assert JSONField == SupportedJSONField

--- a/runtests.py
+++ b/runtests.py
@@ -26,6 +26,9 @@ DEFAULT_SETTINGS = dict(
 
 
 def runtests(*test_args):
+    if django.VERSION < (3, 1):
+        DEFAULT_SETTINGS["INSTALLED_APPS"].append("django_jsonfield_backport")
+
     if not settings.configured:
         settings.configure(**DEFAULT_SETTINGS)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "5.0.0"
+VERSION = "5.1.0"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-eventlog.svg
     :target: https://pypi.python.org/pypi/pinax-eventlog/
@@ -43,6 +43,8 @@ Supported Django and Python Versions
 +-----------------+-----+-----+-----+
 | Django / Python | 3.6 | 3.7 | 3.8 |
 +=================+=====+=====+=====+
+|  2.2            |  *  |  *  |  *  |
+|  3.0            |  *  |  *  |  *  |
 |  3.1            |  *  |  *  |  *  |
 +-----------------+-----+-----+-----+
 """
@@ -77,10 +79,15 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[
-        "django>=3.1",
+        "django>=2.2",
     ],
     tests_require=[
     ],
+    extras_require={
+        "django-lts": [
+            "django-jsonfield-backport>=1.0.0<2",
+        ]
+    },
     test_suite="runtests.runtests",
     zip_safe=False
 )

--- a/tox.ini
+++ b/tox.ini
@@ -15,12 +15,12 @@ skip_glob=**/*/migrations/*
 
 [coverage:run]
 source = pinax
-omit = **/*/conf.py,**/*/tests/*,**/*/migrations/*,**/*/admin.py
+omit = **/*/conf.py,**/*/tests/*,**/*/migrations/*,**/*/admin.py,**/*/compat.py
 branch = true
 data_file = .coverage
 
 [coverage:report]
-omit = **/*/conf.py,**/*/tests/*,**/*/migrations/*,**/*/admin.py
+omit = **/*/conf.py,**/*/tests/*,**/*/migrations/*,**/*/admin.py,**/*/compat.py
 exclude_lines =
     coverage: omit
 show_missing = True
@@ -28,15 +28,18 @@ show_missing = True
 [tox]
 envlist =
     checkqa,
-    py{36,37,38}-dj{31}
+    py{36,37,38}-dj{22-extras,30-extras,31}
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*
 deps =
     coverage<5
     codecov
-    dj30: Django>=3.1
-    master: https://github.com/django/django/tarball/master
+    dj22-extras: Django>=2.2,<3.0
+    dj22-extras: django-jsonfield-backport>=1.0.0,<2
+    dj30-extras: Django>=3.0,<3.1
+    dj30-extras: django-jsonfield-backport>=1.0.0,<2
+    dj31: Django>=3.1,<3.2
 
 usedevelop = True
 commands =


### PR DESCRIPTION
Closes #34

Changes proposed in this PR:

- support Django 2.2.x and 3.0.x via django-jsonfield-backport

See discussion in #34